### PR TITLE
[FEAT] 토스트메세지, 모달창 스토리북 추가 (#60)

### DIFF
--- a/src/stories/modal/Modal.stories.ts
+++ b/src/stories/modal/Modal.stories.ts
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { Modal } from './index';
+
+const meta: Meta<typeof Modal> = {
+    title: 'GlobalComponent/Modal',
+    component: Modal,
+    parameters: {
+        layout: 'centered'
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        onConfirm: { action: 'confirmed' },
+        onCancel: { action: 'cancelled' }
+    }
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        message: 'Modal Message',
+        confirmText: 'Confirm Text',
+        cancelText: 'Cancel Text',
+        onConfirm: () => console.log('로그아웃'),
+        onCancel: () => console.log('취소'),
+    }
+};

--- a/src/stories/modal/index.styles.tsx
+++ b/src/stories/modal/index.styles.tsx
@@ -1,0 +1,51 @@
+import { css, SerializedStyles } from "@emotion/react";
+
+export default {
+    modalContainer(): SerializedStyles {
+        return css`
+        /* position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%); */
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        background-color: white;
+        border-radius: 20px;
+        text-align: center;
+        white-space: normal;
+        box-sizing: border-box;
+        `;
+    },
+    modalMessage(): SerializedStyles {
+        return css`
+        font-size: 16px;
+        font-weight: 600;
+        text-align: center;
+        padding: 16px 36px;
+        border-bottom: 1px solid #D9D9D9;
+        `;
+    },
+    confirmButton(): SerializedStyles {
+        return css`
+        color: #FF0000;
+        font-size: 16px;
+        font-weight: 600;
+        padding: 12px 36px;
+        border-bottom: 1px solid #D9D9D9;
+        width: 100%;
+        box-sizing: border-box;
+        cursor: pointer;
+        `;
+    },
+    cancelButton(): SerializedStyles {
+        return css`
+        color: #000000;
+        font-size: 16px;
+        font-weight: 400;
+        padding: 12px 36px;
+        cursor: pointer;
+        `;
+    }
+};

--- a/src/stories/modal/index.tsx
+++ b/src/stories/modal/index.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import styles from './index.styles';
+
+interface ModalProps {
+    message: string;
+    confirmText: string;
+    cancelText: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export function Modal({
+    message,
+    confirmText,
+    cancelText,
+    onConfirm,
+    onCancel
+}: ModalProps) {
+    const [isVisible, setIsVisible] = useState(true);
+
+    const handleCancel = () => {
+        setIsVisible(false);
+        onCancel();
+    };
+
+    if (!isVisible) return null;
+
+    return (
+        <div css={styles.modalContainer}>
+            <div css={styles.modalMessage}>{message}</div>
+            <div css={styles.confirmButton} onClick={onConfirm}>{confirmText}</div>
+            <div css={styles.cancelButton} onClick={handleCancel}>{cancelText}</div>
+        </div>
+    );
+}

--- a/src/stories/toast/Toast.stories.ts
+++ b/src/stories/toast/Toast.stories.ts
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Toast } from './';
+
+const meta = {
+  title: 'GlobalComponent/Toast',
+  component: Toast,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    direction: {
+      control: {
+        type: 'radio',
+        options: ['none', 'up', 'down']
+      },
+      defaultValue: 'none',
+    },
+    message: {
+      control: 'text',
+      defaultValue: 'Toast Message',
+    }
+  }
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    message: 'Toast Message',
+    direction: 'none'
+  }
+};

--- a/src/stories/toast/index.styles.tsx
+++ b/src/stories/toast/index.styles.tsx
@@ -4,10 +4,10 @@ export default {
     // 토스트 메시지 기본 스타일
     toastMessage(direction: 'none' | 'up' | 'down'): SerializedStyles {
         return css`
-        /* position: fixed;
+        position: fixed;
         top: 50%;
         left: 50%;
-        transform: translate(-50%, -50%); */
+        transform: translate(-50%, -50%);
         padding: 16px;
         background-color: rgba(0, 0, 0, 0.25);
         backdrop-filter: blur(8px);
@@ -22,10 +22,10 @@ export default {
         opacity: 1;
         transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
 
-        &.animate {
+        /* &.animate {
             opacity: 0;
             transform: translate(-50%, ${direction === 'up' ? '-100%' : '100%'});
-        }
+        } */
         /* ${direction === 'up' ? 'transform: translateY(-150%);' : 'transform: translateY(150%);'}; */
         `;
     },

--- a/src/stories/toast/index.styles.tsx
+++ b/src/stories/toast/index.styles.tsx
@@ -1,0 +1,32 @@
+import { css, SerializedStyles } from "@emotion/react";
+
+export default {
+    // 토스트 메시지 기본 스타일
+    toastMessage(direction: 'none' | 'up' | 'down'): SerializedStyles {
+        return css`
+        /* position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%); */
+        padding: 16px;
+        background-color: rgba(0, 0, 0, 0.25);
+        backdrop-filter: blur(8px);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+        color: #FFFFFF;
+        border-radius: 8px;
+        font-size: 16px;
+        font-weight: 400;
+        box-sizing: border-box;
+        white-space: normal;
+        text-align: center;
+        opacity: 1;
+        transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+
+        &.animate {
+            opacity: 0;
+            transform: translate(-50%, ${direction === 'up' ? '-100%' : '100%'});
+        }
+        /* ${direction === 'up' ? 'transform: translateY(-150%);' : 'transform: translateY(150%);'}; */
+        `;
+    },
+};

--- a/src/stories/toast/index.tsx
+++ b/src/stories/toast/index.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import styles from "./index.styles";
+
+interface ToastProps {
+  message: string;
+  direction?: 'none' | 'up' | 'down';
+}
+
+
+export function Toast({
+  message,
+  direction = 'none'
+}: ToastProps) {
+  const [style, setStyle] = useState({
+    opacity: 1, 
+    transform: 'translate(-50%, -50%)'
+  });
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setStyle({
+        opacity: 0,
+        transform: `translate(-50%, ${direction === 'up' ? '-100%' : direction === 'down' ? '100%' : '-50%'})`
+      });
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [direction]);
+
+  return (
+    <div css={styles.toastMessage(direction)} style={style}>
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
### PR 제목
[FEAT] 토스트메세지, 모달창 스토리북 추가 (#60)
UP-79

### 🔗 연관된 이슈 번호

// close #60

### ✨ 어떤 기능을 개발했나요?

1. 토스트메세지 스토리북 추가
2. 모달창 스토리북 추가

### ✅ 어떤 문제를 해결했나요?

- 

### 🗂️ 관련 논의 내용 Link (Option)

- 

### 🚀 결과 이미지 (Option)
<img width="1040" alt="스크린샷 2024-12-02 오후 2 38 18" src="https://github.com/user-attachments/assets/82c35013-b9f6-400c-a58f-cf32cb24727f">
<img width="1046" alt="스크린샷 2024-12-02 오후 3 50 11" src="https://github.com/user-attachments/assets/4a312e09-ceb2-4ef1-aff7-097e6f778b0e">
