### PR TITLE
[FIX] 장르 최대 3개만 띄우기

### DIFF
--- a/src/pages/social/post/index.tsx
+++ b/src/pages/social/post/index.tsx
@@ -244,7 +244,7 @@ export default function SocialPost() {
           </div>
           <div css={movieGenres}>
             {selectedMovie?.genres?.length > 0 ? (
-              selectedMovie.genres.map((genre, idx) => (
+              selectedMovie.genres.slice(0, 3).map((genre, idx) => (
                 <span key={`${genre.genreId}-${idx}`}>
                   {genre.name in GENRE_EMOJI ? (
                     <>
@@ -254,8 +254,7 @@ export default function SocialPost() {
                     </>
                   ) : (
                     genre.name
-                  )}{" "}
-                  {/* 매칭되지 않을 경우 기본 이름만 출력 */}
+                  )}
                 </span>
               ))
             ) : (


### PR DESCRIPTION
### PR 제목
[FIX] 장르 최대 3개만 띄우기

### 🔗 연관된 이슈 번호

// close #이슈번호

### ✨ 어떤 기능을 개발했나요?

1. 장르 최대 3개만 띄우기